### PR TITLE
Seeking and Record Offsets

### DIFF
--- a/record/record.go
+++ b/record/record.go
@@ -97,8 +97,14 @@ const (
 )
 
 const (
-	blockSize  = 32 * 1024
-	headerSize = 7
+	blockSize     = 32 * 1024
+	blockSizeMask = blockSize - 1
+	headerSize    = 7
+)
+
+var (
+	// ErrNotAnIOSeeker is returned if the io.Reader underlying a Reader does not implement io.Seeker.
+	ErrNotAnIOSeeker = errors.New("leveldb/record: reader does not implement io.Seeker")
 )
 
 type flusher interface {
@@ -233,6 +239,48 @@ func (r *Reader) Recover() {
 	return
 }
 
+// SeekRecord seeks in the underlying io.Reader such that calling r.Next returns
+// the record whose first chunk header starts at the given offset in the
+// underlying io.Reader. If there is an unrecovered error, the caller should
+// call Recover before calling SeekRecord. SeekRecord will clear the pending
+// error. Its behavior is undefined if the argument given is not such an offset,
+// as the bytes at that offset may coincidentally appear to be a valid header.
+// The offset is always relative to the start of the io.Reader, thus negative
+// values result in an error.
+//
+// It returns ErrNotAnIOSeeker if the underlying io.Reader does not also
+// implement io.Seeker.
+func (r *Reader) SeekRecord(offset int64) error {
+	r.seq++
+	if r.err != nil {
+		return r.err
+	}
+
+	s, ok := r.r.(io.Seeker)
+	if !ok {
+		return ErrNotAnIOSeeker
+	}
+
+	// Only seek to an exact block offset.
+	c := int(offset & blockSizeMask)
+	if _, r.err = s.Seek(offset&^blockSizeMask, io.SeekStart); r.err != nil {
+		return r.err
+	}
+
+	// Clear the state of the internal reader.
+	r.i, r.j, r.n = 0, 0, 0
+	r.recovering, r.started, r.last = false, false, false
+	if r.err = r.nextChunk(false); r.err != nil {
+		return r.err
+	}
+
+	// Now skip to the offset requested within the block. A subsequent
+	// call to Next will return the block at the requested offset.
+	r.i, r.j = c, c
+
+	return nil
+}
+
 type singleReader struct {
 	r   *Reader
 	seq int
@@ -273,6 +321,16 @@ type Writer struct {
 	// buf[:written] has already been written to w.
 	// written is zero unless Flush has been called.
 	written int
+	// baseOffset is the base offset in w at which writing started. If
+	// w implements io.Seeker, it's relative to the start of w, 0 otherwise.
+	baseOffset int64
+	// blockNumber is the zero based block number currently represented by buf.
+	blockNumber int64
+	// lastRecordOffset is the offset in w at which that the last record was
+	// written (including chunk header). It is a relative offset to
+	// baseOffset, thus the absolute offset of the last record is baseOffset +
+	// lastRecordOffset.
+	lastRecordOffset int64
 	// first is whether the current chunk is the first chunk of the record.
 	first bool
 	// pending is whether a chunk is buffered but not yet written.
@@ -286,9 +344,18 @@ type Writer struct {
 // NewWriter returns a new Writer.
 func NewWriter(w io.Writer) *Writer {
 	f, _ := w.(flusher)
+
+	var o int64
+	if s, ok := w.(io.Seeker); ok {
+		var err error
+		if o, err = s.Seek(0, io.SeekCurrent); err != nil {
+			o = 0
+		}
+	}
 	return &Writer{
-		w: w,
-		f: f,
+		w:          w,
+		f:          f,
+		baseOffset: o,
 	}
 }
 
@@ -321,6 +388,7 @@ func (w *Writer) writeBlock() {
 	w.i = 0
 	w.j = headerSize
 	w.written = 0
+	w.blockNumber++
 }
 
 // writePending finishes the current record and writes the buffer to the
@@ -391,6 +459,22 @@ func (w *Writer) Next() (io.Writer, error) {
 	return singleWriter{w, w.seq}, nil
 }
 
+// LastRecordOffset returns the offset in the underlying io.Writer of the last
+// record so far - the one created by the most recent Next call. It is the
+// offset of the first chunk header, suitable to pass to Reader.SeekRecord.
+//
+// If that io.Writer also implements io.Seeker, the return value is an absolute
+// offset, in the sense of io.SeekStart, regardless of whether the io.Writer
+// was initially at the zero position when passed to NewWriter. Otherwise, the
+// return value is a relative offset, being the number of bytes written between
+// the NewWriter call and any records written prior to the last record.
+func (w *Writer) LastRecordOffset() (int64, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	return w.lastRecordOffset, nil
+}
+
 type singleWriter struct {
 	w   *Writer
 	seq int
@@ -404,6 +488,7 @@ func (x singleWriter) Write(p []byte) (int, error) {
 	if w.err != nil {
 		return 0, w.err
 	}
+	w.lastRecordOffset = w.baseOffset + w.blockNumber*blockSize + int64(w.i)
 	n0 := len(p)
 	for len(p) > 0 {
 		// Write a block, if it is full.

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -676,17 +676,16 @@ func TestSeekRecord(t *testing.T) {
 		t.Fatalf("Unexpected output in record 1's data, got %v want %v", rData, recs.records[1])
 	}
 
-	// Seek to 3 bytes into the second block, which is still in the middle of the first record, but not
-	// at a valid chunk boundary.
+	// Seek 3 bytes into the second block, which is still in the middle of the first record, but not
+	// at a valid chunk boundary. Should result in an error upon calling r.Next.
 	err = r.SeekRecord(blockSize + 3)
 	if err != nil {
 		t.Fatalf("SeekRecord: %v", err)
 	}
-
 	if _, err = r.Next(); err == nil {
-		t.Fatalf("Unexpected lack of error calling SeekRecord to a bad offset")
+		t.Fatalf("Expected an error seeking to an invalid chunk boundary")
 	}
-	r.Recover() // Recover from the faux error just generated.
+	r.Recover()
 
 	// Seek to the fifth block and verify all records can be read as appropriate.
 	err = r.SeekRecord(blockSize * 4)
@@ -732,15 +731,6 @@ func TestSeekRecord(t *testing.T) {
 		t.Fatalf("SeekRecord: %v", err)
 	}
 	check(2)
-
-	// Seek to an invalid chunk boundary. Should result in an error upon calling r.Next.
-	err = r.SeekRecord(blockSize + 3)
-	if err != nil {
-		t.Fatalf("Seeking to an invalid chunk boundary isn't an error")
-	}
-	if _, err = r.Next(); err == nil {
-		t.Fatalf("Expected an error jumping to an invalid chunk boundary")
-	}
 }
 
 func TestLastRecordOffset(t *testing.T) {

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -320,6 +320,7 @@ func TestStaleWriter(t *testing.T) {
 
 type testRecords struct {
 	records [][]byte // The raw value of each record.
+	offsets []int64  // The offset of each record within buf, derived from writer.LastRecordOffset.
 	buf     []byte   // The serialized records form of all records.
 }
 
@@ -329,18 +330,23 @@ type testRecords struct {
 func makeTestRecords(recordLengths ...int) (*testRecords, error) {
 	ret := &testRecords{}
 	ret.records = make([][]byte, len(recordLengths))
+	ret.offsets = make([]int64, len(recordLengths))
 	for i, n := range recordLengths {
 		ret.records[i] = bytes.Repeat([]byte{byte(i)}, n)
 	}
 
 	buf := new(bytes.Buffer)
 	w := NewWriter(buf)
-	for _, rec := range ret.records {
+	for i, rec := range ret.records {
 		wRec, err := w.Next()
 		if err != nil {
 			return nil, err
 		}
 		if _, err = wRec.Write(rec); err != nil {
+			return nil, err
+		}
+		ret.offsets[i], err = w.LastRecordOffset()
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -634,5 +640,130 @@ func TestRecoverLastCompleteBlock(t *testing.T) {
 	// Verify Recover works when the last block is corrupted.
 	if err := verifyLastBlockRecover(recs); err != nil {
 		t.Fatalf("verifyLastBlockRecover: %v", err)
+	}
+}
+
+func TestSeekRecord(t *testing.T) {
+	recs, err := makeTestRecords(
+		// The first record will consume 3 entire blocks but a fraction of the 4th.
+		blockSize*3,
+		// The second record will completely fill the remainder of the 4th block.
+		3*(blockSize-headerSize)-2*blockSize-2*headerSize,
+		// Consume the entirety of the 5th block.
+		blockSize-headerSize,
+		// Consume the entirety of the 6th block.
+		blockSize-headerSize,
+		// Consume roughly half of the 7th block.
+		blockSize/2,
+	)
+	if err != nil {
+		t.Fatalf("makeTestRecords: %v", err)
+	}
+
+	r := NewReader(bytes.NewReader(recs.buf))
+	// Seek to a valid block offset, but within a multiblock record. This should cause the next call to
+	// Next after SeekRecord to return the next valid FIRST/FULL chunk of the subsequent record.
+	err = r.SeekRecord(blockSize)
+	if err != nil {
+		t.Fatalf("SeekRecord: %v", err)
+	}
+	rec, err := r.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	rData, _ := ioutil.ReadAll(rec)
+	if !bytes.Equal(rData, recs.records[1]) {
+		t.Fatalf("Unexpected output in record 1's data, got %v want %v", rData, recs.records[1])
+	}
+
+	// Seek to 3 bytes into the second block, which is still in the middle of the first record, but not
+	// at a valid chunk boundary.
+	err = r.SeekRecord(blockSize + 3)
+	if err != nil {
+		t.Fatalf("SeekRecord: %v", err)
+	}
+
+	if _, err = r.Next(); err == nil {
+		t.Fatalf("Unexpected lack of error calling SeekRecord to a bad offset")
+	}
+	r.Recover() // Recover from the faux error just generated.
+
+	// Seek to the fifth block and verify all records can be read as appropriate.
+	err = r.SeekRecord(blockSize * 4)
+	if err != nil {
+		t.Fatalf("SeekRecord: %v", err)
+	}
+
+	recLooper := func(i int) {
+		for ; i < len(recs.records); i++ {
+			rec, err := r.Next()
+			if err != nil {
+				t.Fatalf("Next: %v", err)
+			}
+
+			rData, _ := ioutil.ReadAll(rec)
+			if !bytes.Equal(rData, recs.records[i]) {
+				t.Fatalf("Unexpected output in record #%d's data, got %v want %v", i, rData, recs.records[i])
+			}
+		}
+	}
+	recLooper(2)
+
+	// Seek back to the fourth block, and read all subsequent records and verify them.
+	err = r.SeekRecord(blockSize * 3)
+	if err != nil {
+		t.Fatalf("SeekRecord: %v", err)
+	}
+	recLooper(1)
+
+	// Now seek past the end of the file and verify it causes an error.
+	err = r.SeekRecord(1 << 20)
+	if err == nil {
+		t.Fatalf("Seek past the end of a file didn't cause an error")
+	}
+	if err != io.EOF {
+		t.Fatalf("Seeking past EOF raised unexpected error: %v", err)
+	}
+	r.Recover() // Verify recovery works.
+
+	// Validate the current records are returned after seeking to a valid offset.
+	err = r.SeekRecord(blockSize * 4)
+	if err != nil {
+		t.Fatalf("SeekRecord: %v", err)
+	}
+	recLooper(2)
+
+	// Seek to an invalid chunk boundary. Should result in an error upon calling r.Next.
+	err = r.SeekRecord(blockSize + 3)
+	if err != nil {
+		t.Fatalf("Seeking to an invalid chunk boundary isn't an error")
+	}
+	if _, err = r.Next(); err == nil {
+		t.Fatalf("Expected an error jumping to an invalid chunk boundary")
+	}
+}
+
+func TestLastRecordOffset(t *testing.T) {
+	recs, err := makeTestRecords(
+		// The first record will consume 3 entire blocks but a fraction of the 4th.
+		blockSize*3,
+		// The second record will completely fill the remainder of the 4th block.
+		3*(blockSize-headerSize)-2*blockSize-2*headerSize,
+		// Consume the entirety of the 5th block.
+		blockSize-headerSize,
+		// Consume the entirety of the 6th block.
+		blockSize-headerSize,
+		// Consume roughly half of the 7th block.
+		blockSize/2,
+	)
+	if err != nil {
+		t.Fatalf("makeTestRecords: %v", err)
+	}
+
+	wants := []int64{0, 98332, 131072, 163840, 196608}
+	for i, got := range recs.offsets {
+		if want := wants[i]; got != want {
+			t.Errorf("record #%d: got %d, want %d", i, got, want)
+		}
 	}
 }


### PR DESCRIPTION
Add support for seeking within record files while reading.
Add support for easily accessing the offset at which records are written when writing.

These two features obviously go hand in hand, and make random access within record files practical.